### PR TITLE
Add venv activation to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@ cd mission-1-1-fleet-census
 
 # 2. Start the fleet
 make setup
+
+# 3. Activate the Python environment
+source venv/bin/activate
 ```
 
-3. **Read your orders**: [Mission Briefing](docs/BRIEFING.md)
-4. **Complete the exercises**: [Exercises](docs/EXERCISES.md)
-5. **Stuck?** [Hints & Troubleshooting](docs/HINTS.md)
-6. **Track progress**: [Checklist](CHECKLIST.md)
+4. **Read your orders**: [Mission Briefing](docs/BRIEFING.md)
+5. **Complete the exercises**: [Exercises](docs/EXERCISES.md)
+6. **Stuck?** [Hints & Troubleshooting](docs/HINTS.md)
+7. **Track progress**: [Checklist](CHECKLIST.md)
 
 ## Lab Architecture
 

--- a/docs/EXERCISES.md
+++ b/docs/EXERCISES.md
@@ -41,7 +41,17 @@ This builds the Docker containers, generates SSH credentials, and starts all thr
   Fleet Status: 3 nodes ONLINE
 ```
 
-### Step 0.2 — If Things Go Wrong
+### Step 0.2 — Activate the Python Environment
+
+`make setup` creates a Python virtual environment with Ansible and testing tools. **Activate it** before running any Ansible commands:
+
+```bash
+source venv/bin/activate
+```
+
+Your terminal prompt will show `(venv)` when active. You need to do this once per terminal session. If you open a new terminal, activate again.
+
+### Step 0.3 — If Things Go Wrong
 
 If containers are in a bad state or you need a clean start at any point during the mission:
 


### PR DESCRIPTION
## Summary
- Add venv activation step to EXERCISES.md Phase 0 (new Step 0.2, renumbered existing Step 0.2 to 0.3)
- Add venv activation to README.md Quick Start (step 3, renumbered subsequent steps)

Students need `source venv/bin/activate` before running ansible commands. Pattern matches mission-1-2-lock-the-door.